### PR TITLE
幅優先探索の実装を修正

### DIFF
--- a/chukyu/python/chapter06/section03/6-3-1.py
+++ b/chukyu/python/chapter06/section03/6-3-1.py
@@ -1,4 +1,4 @@
-# https://atcoder.jp/contests/abc007/submissions/20049997
+# https://atcoder.jp/contests/abc007/submissions/20864463
 
 from collections import deque
 
@@ -35,7 +35,7 @@ while len(Q) > 0:
         if not (0 <= i2 < R and 0 <= j2 < C):
             continue
         # もし壁マスであれば無視する。
-        if S[i][j] == '#':
+        if S[i2][j2] == '#':
             continue
         # もし未訪問（dist[i2][j2] が -1）であれば、距離を更新してキューに入れる。
         if dist[i2][j2] == -1:


### PR DESCRIPTION
幅優先探索の実装を修正します。

修正前の実装でも不正解にはならないものの、解説の意図に合っていない実装になっていました。